### PR TITLE
Add IRCv3.2 tag compatibility

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -164,8 +164,8 @@ end
 -- http://calebdelnay.com/blog/2010/11/parsing-the-irc-message-format-as-a-client
 local function parse_message(message_tagged)
 	-- Tags
-	local tagged, tags, message
-	if message:sub(1, 1) == "@" then
+	local tags, message
+	if message_tagged:sub(1, 1) == "@" then
 		local tag_space = message_tagged:find(" ")
 		tags = parse_tags(message_tagged:sub(2, tag_space - 1))
 		message = message_tagged:sub(tag_space + 1)
@@ -198,7 +198,7 @@ local function parse_message(message_tagged)
 	local command = the_rest[1]
 	table.remove(the_rest, 1)
 	table.insert(the_rest, trailing)
-	return prefix, command, the_rest
+	return prefix, command, the_rest, tags
 end
 
 -- Calls the handler for the command if there is one, then calls the callback.

--- a/init.lua
+++ b/init.lua
@@ -157,6 +157,11 @@ local function parse_tags(tag_message)
 			end
 		end
 	end
+	if cur_name then
+		tags[cur_name] = table.concat(charbuf)
+	else
+		tags[table.concat(charbuf)] = true
+	end
 	return tags
 end
 

--- a/init.lua
+++ b/init.lua
@@ -168,6 +168,7 @@ local function parse_message(message_tagged)
 		message = message_tagged:sub(tag_space + 1)
 	else
 		message = message_tagged
+	end
 
 	-- Prefix
 	local prefix_end = 0


### PR DESCRIPTION
The [IRCv3](http://ircv3.net/specs/core/message-tags-3.2.html) spec defines a way to add in tags, which are somewhat like a command metadata; this change is supposed to add compatibility with them.

@daurnimator since you had questions about the code length, maybe you could see something to optimize?